### PR TITLE
Add T.one aqua air in FRIENDLY_NAMES

### DIFF
--- a/custom_components/aldes/const.py
+++ b/custom_components/aldes/const.py
@@ -11,4 +11,4 @@ CONF_PASSWORD = "password"
 MANUFACTURER = "Aldes"
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.CLIMATE]
 
-FRIENDLY_NAMES = {"TONE_AIR": "T.One® AIR"}
+FRIENDLY_NAMES = {"TONE_AIR": "T.One® AIR", "TONE_AQUA_AIR": "T.One® AquaAIR"}


### PR DESCRIPTION
Fix issue display on HA, Add "TONE_AQUA_AIR" in const.py FRIENDLY_NAMES

`Error while setting up aldes platform for binary_sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 352, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 533, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 640, in _async_add_entity
    if self.config_entry and (device_info := entity.device_info):
                                             ^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/aldes/binary_sensor.py", line 45, in device_info
    name=f"{FRIENDLY_NAMES[self.reference]} {self.product_serial_number}",
            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'TONE_AQUA_AIR'`