### PR TITLE
BUG - Fix min and max temp value in cool mode

### DIFF
--- a/custom_components/aldes/climate.py
+++ b/custom_components/aldes/climate.py
@@ -96,7 +96,7 @@ class AldesClimateEntity(AldesEntity, ClimateEntity):
             if product["serial_number"] == self.product_serial_number:
                 if product["indicator"]["current_air_mode"] == "B":
                     return product["indicator"]["cmist"]
-                if product["indicator"]["current_air_mode"] == "C":
+                if product["indicator"]["current_air_mode"] == "F":
                     return product["indicator"]["fmist"]
             return None
 
@@ -107,7 +107,7 @@ class AldesClimateEntity(AldesEntity, ClimateEntity):
             if product["serial_number"] == self.product_serial_number:
                 if product["indicator"]["current_air_mode"] == "B":
                     return product["indicator"]["cmast"]
-                if product["indicator"]["current_air_mode"] == "C":
+                if product["indicator"]["current_air_mode"] == "F":
                     return product["indicator"]["fmast"]
             return None
 


### PR DESCRIPTION
I've noticed that the integration no longer works in cool mode since a recent HASS update (https://developers.home-assistant.io/blog/2024/07/24/climate-min-max-temperature-check/).

This was due to an error that prevented the retrieval of the values.